### PR TITLE
Remove space at the end of the kv reference

### DIFF
--- a/Resources/template.json
+++ b/Resources/template.json
@@ -46,7 +46,7 @@
                 "CustomerDatabaseId": "customers",
                 "LeaseCollectionName": "learningprogression-lease",
                 "LeaseCollectionPrefix": "learningprogressionChangeFeedPrefix",
-                "ServiceBusConnectionString": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=ServiceBusConnectionString )', parameters('keyVaultName'))]",
+                "ServiceBusConnectionString": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=ServiceBusConnectionString)', parameters('keyVaultName'))]",
                 "ChangeFeedQueueName": "dss.changefeedqueue",
                 "QueueName": "[parameters('serviceBusQueueName')]",
                 "CosmosDbEndpoint": "[parameters('CosmosDbEndpoint')]"


### PR DESCRIPTION
Change made during the PP release of R99 to remove spacing in kv reference. 

https://sfa-gov-uk.visualstudio.com/National%20Careers%20Service%20(NCS)/_wiki/wikis/National-Careers-Service-(NCS).wiki/17308/(DSS)-Release-99-DSS-Tickets